### PR TITLE
add playwright and ci action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,12 +108,6 @@ jobs:
       with:
         node-version: 21.7.3
 
-    - name: Install PNPM & Dependencies
-      run: npm install -g pnpm && pnpm install
-
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
-
     - name: Set CI Environment Variable
       run: echo "export CI=true" >> $GITHUB_ENV
     # Use your base url
@@ -122,6 +116,13 @@ jobs:
     
     - name: Set Cookie Env Variable
       run: echo "export XSOURCECOOKIE=${{github.sha}}" >> $GITHUB_ENV
+
+    - name: Install PNPM & Dependencies
+      run: npm install -g pnpm && pnpm install
+
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+
     - name: Run Playwright tests
       run: pnpm exec playwright test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4
+      if: !cancelled()
       with:
         name: playwright-report
         path: playwright-report/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,10 @@ jobs:
     needs: uploadBuild
     name: Run Playwright Tests
     runs-on: ubuntu-latest
+    env:
+      CI: true
+      BASE_URL: ${{secrets.BASE_URL}}
+      XSOURCECOOKIE: ${{github.sha}}
 
     steps:
     - name: Checkout
@@ -108,21 +112,13 @@ jobs:
       with:
         node-version: 21.7.3
 
-    - name: Set CI Environment Variable
-      run: echo "export CI=true" >> $GITHUB_ENV
-    # Use your base url
-    - name: Set Base URL
-      run: echo "export BASE_URL=${{secrets.BASE_URL}}" >> $GITHUB_ENV
-    
-    - name: Set Cookie Env Variable
-      run: echo "export XSOURCECOOKIE=${{github.sha}}" >> $GITHUB_ENV
-
     - name: Install PNPM & Dependencies
       run: npm install -g pnpm && pnpm install
 
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
-
+    - name: Validate environment
+      run: env
     - name: Run Playwright tests
       run: pnpm exec playwright test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4
-      if: !cancelled()
+      if: always()
       with:
         name: playwright-report
         path: playwright-report/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Lint, Build, and Test
+name: Lint, Build, Unit Test, and Playwright Tests
 
 on:
   workflow_dispatch:
@@ -75,7 +75,7 @@ jobs:
       run: pnpm test
     
   uploadBuild:
-    needs: build
+    needs: [build, lint, test]
     name: Upload Build to S3
     runs-on: ubuntu-latest
 
@@ -93,3 +93,41 @@ jobs:
         aws-region: us-east-1
     - name: Upload build to S3
       run: aws s3 cp build s3://${{secrets.AWS_S3_PROJECT_DIRECTORY}}/${{github.sha}}/ --recursive
+
+  RunPlayWrightTests:
+    needs: uploadBuild
+    name: Run Playwright Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 21.7.3
+
+    - name: Install PNPM & Dependencies
+      run: npm install -g pnpm && pnpm install
+
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+
+    - name: Set CI Environment Variable
+      run: echo "export CI=true" >> $GITHUB_ENV
+    # Use your base url
+    - name: Set Base URL
+      run: echo "export BASE_URL=${{secrets.BASE_URL}}" >> $GITHUB_ENV
+    
+    - name: Set Cookie Env Variable
+      run: echo "export XSOURCECOOKIE=${{github.sha}}" >> $GITHUB_ENV
+    - name: Run Playwright tests
+      run: pnpm exec playwright test
+
+    - name: Upload Playwright Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,6 @@ jobs:
 
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
-    - name: Validate environment
-      run: env
     - name: Run Playwright tests
       run: pnpm exec playwright test
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist-ssr
 *.sw?
 
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.6",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20.12.10",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,68 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    baseURL: process.env.CI ? process.env.BASE_URL : 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,6 +59,8 @@ export default defineConfig({
     // },
   ],
 
+  testMatch: '**/*spec.ts'
+
   /* Run your local dev server before starting the tests */
   // webServer: {
   //   command: 'npm run start',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,15 +15,21 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.44.0
+        version: 1.44.0
       '@testing-library/jest-dom':
         specifier: ^6.4.5
-        version: 6.4.5(vitest@1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0))
+        version: 6.4.5(vitest@1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0))
       '@testing-library/react':
         specifier: ^15.0.6
         version: 15.0.6(@types/react@18.2.69)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.1.0)
+      '@types/node':
+        specifier: ^20.12.10
+        version: 20.12.10
       '@types/react':
         specifier: ^18.2.66
         version: 18.2.69
@@ -38,10 +44,10 @@ importers:
         version: 7.3.1(eslint@8.57.0)(typescript@5.4.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.2.6)
+        version: 4.2.1(vite@5.2.6(@types/node@20.12.10))
       '@vitest/coverage-v8':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0))
+        version: 1.6.0(vitest@1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0))
       '@vitest/ui':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0)
@@ -62,10 +68,10 @@ importers:
         version: 5.4.3
       vite:
         specifier: ^5.2.0
-        version: 5.2.6
+        version: 5.2.6(@types/node@20.12.10)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0)
+        version: 1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0)
 
 packages:
 
@@ -400,6 +406,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@playwright/test@1.44.0':
+    resolution: {integrity: sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
 
@@ -533,6 +544,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.12.10':
+    resolution: {integrity: sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==}
 
   '@types/prop-types@15.7.12':
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
@@ -951,6 +965,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1303,6 +1322,16 @@ packages:
   pkg-types@1.1.0:
     resolution: {integrity: sha512-/RpmvKdxKf8uILTtoOhAgf30wYbP2Qw+L9p3Rvshx1JZVX+XQNZQFjlbmGHEGIm4CkVPlSn+NXmIM8+9oWQaSA==}
 
+  playwright-core@1.44.0:
+    resolution: {integrity: sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  playwright@1.44.0:
+    resolution: {integrity: sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1529,6 +1558,9 @@ packages:
 
   ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -1968,6 +2000,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@playwright/test@1.44.0':
+    dependencies:
+      playwright: 1.44.0
+
   '@polka/url@1.0.0-next.25': {}
 
   '@rollup/rollup-android-arm-eabi@4.13.0':
@@ -2022,7 +2058,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.5(vitest@1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0))':
+  '@testing-library/jest-dom@6.4.5(vitest@1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.24.5
@@ -2033,7 +2069,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
     optionalDependencies:
-      vitest: 1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0)
+      vitest: 1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0)
 
   '@testing-library/react@15.0.6(@types/react@18.2.69)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -2075,6 +2111,10 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.12.10':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/prop-types@15.7.12': {}
 
@@ -2180,18 +2220,18 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react@4.2.1(vite@5.2.6)':
+  '@vitejs/plugin-react@4.2.1(vite@5.2.6(@types/node@20.12.10))':
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.24.3)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.3)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.2.6
+      vite: 5.2.6(@types/node@20.12.10)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0))':
+  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -2206,7 +2246,7 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0)
+      vitest: 1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2241,7 +2281,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0)
+      vitest: 1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0)
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -2601,6 +2641,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2940,6 +2983,14 @@ snapshots:
       mlly: 1.7.0
       pathe: 1.1.2
 
+  playwright-core@1.44.0: {}
+
+  playwright@1.44.0:
+    dependencies:
+      playwright-core: 1.44.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss@8.4.38:
     dependencies:
       nanoid: 3.3.7
@@ -3141,6 +3192,8 @@ snapshots:
 
   ufo@1.5.3: {}
 
+  undici-types@5.26.5: {}
+
   universalify@0.2.0: {}
 
   update-browserslist-db@1.0.13(browserslist@4.23.0):
@@ -3158,13 +3211,13 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  vite-node@1.6.0:
+  vite-node@1.6.0(@types/node@20.12.10):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.6
+      vite: 5.2.6(@types/node@20.12.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3175,15 +3228,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.6:
+  vite@5.2.6(@types/node@20.12.10):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.13.0
     optionalDependencies:
+      '@types/node': 20.12.10
       fsevents: 2.3.3
 
-  vitest@1.6.0(@vitest/ui@1.6.0)(jsdom@24.0.0):
+  vitest@1.6.0(@types/node@20.12.10)(@vitest/ui@1.6.0)(jsdom@24.0.0):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -3202,10 +3256,11 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.2.6
-      vite-node: 1.6.0
+      vite: 5.2.6(@types/node@20.12.10)
+      vite-node: 1.6.0(@types/node@20.12.10)
       why-is-node-running: 2.2.2
     optionalDependencies:
+      '@types/node': 20.12.10
       '@vitest/ui': 1.6.0(vitest@1.6.0)
       jsdom: 24.0.0
     transitivePeerDependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,9 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+        <span>
+          this text is specific to this pr
+        </span>
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,9 +24,6 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
-        <span>
-          this text is specific to this pr
-        </span>
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -8,5 +8,6 @@ test('has title', async ({ page, context }) => {
   await page.goto('/')
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle("Vite + React + TS");
+  await expect(page.getByText('this text is specific to this pr')).toBeDefined()
 });
 

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page, context }) => {
+  if (process.env.CI && process.env.XSOURCECOOKIE) {
+    const cookie = process.env.XSOURCECOOKIE
+    await context.addCookies([{ name: 'X-source', value: cookie }]);
+    page.goto('/')
+  }
+});
+
+test('has title', async ({ page }) => {
+
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle("Vite + React + TS");
+});
+

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -5,7 +5,7 @@ test('has title', async ({ page, context }) => {
   console.log('XSOURCECOOKIE:', process.env.XSOURCECOOKIE);
   if (process.env.CI && process.env.XSOURCECOOKIE) {
     const cookie = process.env.XSOURCECOOKIE
-    await context.addCookies([{ name: 'X-source', value: cookie }]);
+    await context.addCookies([{ name: 'X-source', value: cookie, domain: 'devopswithme.net' }]);
   }
   await page.goto('/')
   // Expect a title "to contain" a substring.

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 test('has title', async ({ page, context }) => {
-
+  console.log('CI:', process.env.CI);
+  console.log('XSOURCECOOKIE:', process.env.XSOURCECOOKIE);
   if (process.env.CI && process.env.XSOURCECOOKIE) {
     const cookie = process.env.XSOURCECOOKIE
     await context.addCookies([{ name: 'X-source', value: cookie }]);

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -8,6 +8,5 @@ test('has title', async ({ page, context }) => {
   await page.goto('/')
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle("Vite + React + TS");
-  await expect(page.getByText('this text is specific to this pr')).toBeDefined()
 });
 

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,16 +1,12 @@
 import { test, expect } from '@playwright/test';
 
-test.beforeEach(async ({ page, context }) => {
+test('has title', async ({ page, context }) => {
+
   if (process.env.CI && process.env.XSOURCECOOKIE) {
     const cookie = process.env.XSOURCECOOKIE
     await context.addCookies([{ name: 'X-source', value: cookie }]);
-    page.goto('/')
   }
-});
-
-test('has title', async ({ page }) => {
-
-
+  await page.goto('/')
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle("Vite + React + TS");
 });

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('has title', async ({ page, context }) => {
   if (process.env.CI && process.env.XSOURCECOOKIE) {
     const cookie = process.env.XSOURCECOOKIE
-    await context.addCookies([{ name: 'X-source', value: cookie }]);
+    await context.addCookies([{ name: 'X-source', value: cookie, url: process.env.BASE_URL ?? 'http://localhost:5173' }]);
   }
   await page.goto('/')
   // Expect a title "to contain" a substring.

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 test('has title', async ({ page, context }) => {
-  console.log('CI:', process.env.CI);
-  console.log('XSOURCECOOKIE:', process.env.XSOURCECOOKIE);
   if (process.env.CI && process.env.XSOURCECOOKIE) {
     const cookie = process.env.XSOURCECOOKIE
-    await context.addCookies([{ name: 'X-source', value: cookie, domain: 'devopswithme.net' }]);
+    await context.addCookies([{ name: 'X-source', value: cookie }]);
   }
   await page.goto('/')
   // Expect a title "to contain" a substring.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,14 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**.spec.ts',
+      '**/tests/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      './src/config/**',
+    ]
   },
 })


### PR DESCRIPTION
This pr brings in Playwright. Playwright can be ran locally and is now running in CI. In order to access the version of the app that's currently in CI, playwright is reading in from the environment the github commit sha and setting the `X-source` cookie on the browser context. The playwright step occurs after the build has already been uploaded to s3 and can be routed to directly using the `X-source` cookie. I noticed playwright was downloading firefox in CI, I'll need to update the config to just use chromium but for now this works. 