### PR TITLE
LinkedIn Post - Validating CI changes using Cookie

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -25,6 +25,12 @@ test('home page counter', async () => {
     expect(screen.getByText(/count is 3/i)).not.toBeNull()
 })
 
+test('should have a card with a link to a LinkedIn post', () => {
+
+    const link = screen.getByText(/LinkedIn Post about this/i)
+    expect(link).not.toBeNull()
+})
+
 test.each(links)('should have a link to %s', (linkText) => {
 
     const link = screen.getByAltText(linkText)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,16 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
+        <p>
+          This is an example of a change in code that can be validated in a testing framework in a CI pipeline
+        </p>
+        <small>
+          <a href="https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs?utm_source=share&utm_medium=member_desktop" target="_blank">
+            LinkedIn Post about this
+          </a>
+        </small>
+      </div>
+      <div className="card">
         <button name='count' onClick={() => setCount((count) => count + 1)}>
           count is {count}
         </button>

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -9,13 +9,8 @@ test('has title', async ({ page, context }) => {
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle("Vite + React + TS");
 
-  // Expect an element matching text.
-});
-
-test('has a card with a link to a LinkedIn post', async ({ page }) => {
   await page.goto('/')
   const link = await page.getByRole('link', { name: /LinkedIn Post about this/i });
   await expect(link).toBeDefined();
   await expect(link).toHaveAttribute('href', 'https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs?utm_source=share&utm_medium=member_desktop')
 });
-

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -8,5 +8,14 @@ test('has title', async ({ page, context }) => {
   await page.goto('/')
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle("Vite + React + TS");
+
+  // Expect an element matching text.
+});
+
+test('has a card with a link to a LinkedIn post', async ({ page }) => {
+  await page.goto('/')
+  const link = await page.getAttribute('text=LinkedIn Post about this', 'href');
+  await expect(link).toBeDefined();
+  await expect(link).toHaveProperty('href', 'https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs/?utm_source=share&utm_medium=member_desktop');
 });
 

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -14,8 +14,8 @@ test('has title', async ({ page, context }) => {
 
 test('has a card with a link to a LinkedIn post', async ({ page }) => {
   await page.goto('/')
-  const link = await page.getAttribute('text=LinkedIn Post about this', 'href');
+  const link = await page.getByRole('link', { name: /LinkedIn Post about this/i });
   await expect(link).toBeDefined();
-  await expect(link).toHaveProperty('href', 'https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs/?utm_source=share&utm_medium=member_desktop');
+  await expect(link).toHaveAttribute('href', 'https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs/?utm_source=share&utm_medium=member_desktop');
 });
 

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -16,6 +16,6 @@ test('has a card with a link to a LinkedIn post', async ({ page }) => {
   await page.goto('/')
   const link = await page.getByRole('link', { name: /LinkedIn Post about this/i });
   await expect(link).toBeDefined();
-  await expect(link).toHaveAttribute('href', 'https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs/?utm_source=share&utm_medium=member_desktop');
+  await expect(link).toHaveAttribute('href', 'https://www.linkedin.com/posts/daniel-wh_github-daniel-whcommithashdeploy-activity-7213178505499475968-JjVs?utm_source=share&utm_medium=member_desktop')
 });
 


### PR DESCRIPTION
You can validate the changes in this PR by going to [](https://dev.devopswithme.net) you can set a cookie in your browser of choice. Cookie name is `X-source` and the value is this PR's commit hash `7de9084edf74662a688f1fe3a876f7a67384cdc0` and then reload the page and you will see this PR's changes.
